### PR TITLE
New parser support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,5 +118,6 @@ dist
 
 # No dev files
 local.settings.json
+production.settings.json
 
 # End of https://www.toptal.com/developers/gitignore/api/node

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "discordvaccinescraperbot",
+  "name": "discord-vaccine-bot",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/src/commandParser.js
+++ b/src/commandParser.js
@@ -1,0 +1,87 @@
+const _ = require('underscore');
+
+// Just here to declutter main, we still need the cmdletDefinitions to be passed in
+class CommandParser {
+    // Sorry for the dampness. We'll sort this out later
+    static getCmdletDefinition(cmdletName, cmdletDefinitions) {
+        let cmdletToLower = cmdletName.toLowerCase();
+        return _.find(cmdletDefinitions, function(cmd) {
+            return cmd.name === cmdletToLower;
+        });
+    }
+
+    static parseCommandTokens(fullContentString, cmdletDefinitions) {
+        let tokens = fullContentString.split(' ');
+
+        // First token is triggerCommand, we don't need to validate that again so skip it.
+        if (tokens.length > 1) {
+            let cmdlet = this.getCmdletDefinition(tokens[1], cmdletDefinitions);
+            if (cmdlet) {            
+                let paramTokens = tokens.slice(2);
+                let requiredParams = _.filter(cmdlet.params, function(c) { return c.isRequired === true; });            
+                
+                // Must meet minimum length requirements
+                if (paramTokens.length < requiredParams.length) {
+                    return { errorMessage: `We think you wanted the \`${cmdlet.name}\` command, but you're missing some parameters.` };
+                }
+                
+                var paramsTable = {};
+                var wildcardValue = null;
+                var wildcardedParamName = null;
+                var captureRemainderAsWildcard = false;
+                for (var i = 0; i < paramTokens.length; ++i) {
+                    let paramValue = paramTokens[i].toLowerCase();
+                    let paramSpec = i < cmdlet.params.length ? cmdlet.params[i] : null;
+
+                    var assignedParamValue = null;
+                    if (paramSpec) {
+                        // Assert position of the paramSpec matches current token position first - otherwise this is a mistake on our part
+                        if (paramSpec.position === i && paramSpec.isWildcard === false) {
+                            if (paramSpec.isSwitch === true) {
+                                // For switches, we'll just require you to match the name of the switch to turn it on.
+                                assignedParamValue = paramSpec.name === paramValue;
+                            }
+                            else {
+                                assignedParamValue = paramValue;
+                            }
+                        }
+                        else if (paramSpec.isWildcard === true) {
+                            // Wildcards capture the remainder of the command as long string buffer. We ignore positional asserts after this point
+                            captureRemainderAsWildcard = true;
+                            wildcardedParamName = paramSpec.name;
+                            wildcardValue = [ paramValue ];
+                            continue;
+                        }
+                        else {
+                            // Just a check against ourselves to ensure we don't muck up the params since we don't intend to write unit tests
+                            throw `Parameter: ${paramSpec.name} has position: ${paramSpec.position} but we're actually on position: ${i}.`
+                        }
+
+                        paramsTable[paramSpec.name] = paramValue;
+                    }                    
+                    else if (captureRemainderAsWildcard) {
+                        wildcardValue.push(paramValue);
+                    }
+                }
+
+                // Concat the wildcard
+                if (captureRemainderAsWildcard === true) {
+                    paramsTable[wildcardedParamName] = wildcardValue.join(' ');
+                }
+                
+                return {
+                    command: cmdlet.name,
+                    cmdlet: cmdlet,
+                    params: paramsTable
+                };
+            }
+
+            return { errorMessage: `We don\'t recognize that command. Type \`${triggerWord} ${helpCommand}\` for a list of commands.` };
+        }
+        else {
+            return { errorMessage: `You need to specify a command. Type \`${triggerWord} ${helpCommand}\` for a list of commands.` };
+        }
+    }
+}
+
+module.exports = CommandParser;

--- a/src/main.js
+++ b/src/main.js
@@ -2,47 +2,53 @@ const http = require('http');
 const Discord = require("discord.js");
 const fs = require("fs");
 const _ = require('underscore');
+const CommandParser = require('./commandParser');
 
 const client = new Discord.Client();
-const settings = JSON.parse(fs.readFileSync("local.settings.json"));
+const settings = JSON.parse(fs.readFileSync("./production.settings.json"));
 const token = settings.token;
 
-const triggerWord = '!vaccine ';
+const longTriggerWord = '!vaccine ';
+const shortTriggerWord = '!vac ';
 const helpCommand = 'help';
 const listCommand = 'list';
-const fromCommand = 'from';
+const schedulesCommand = 'schedules';
 
 const cmdletDefinitions = [
     {
         name: helpCommand,
         params: [
-            { name: '*', isRequired: false, isSwitch: false, position: 0 }
+            { name: 'command', isRequired: false, isSwitch: false, isWildcard: true, position: 0 }
         ],
         asyncHandler: execHelpCommandAsync,
-        helpText: `Usage: *${triggerWord} ${helpCommand}* [command_name]\n\`\`\`Available commands:\n${listCommand}: List vaccine providers\n${fromCommand}: Shows vaccine availability by provider and state\`\`\``
+        helpText: `Usage: *${longTriggerWord} ${helpCommand}* [command_name]\n\`\`\`Available commands:\n${listCommand}: List vaccine providers\n${schedulesCommand}: Shows vaccine availability by provider and state\`\`\``
     },
     {
         name: listCommand,
         params: [
-            { name: 'providers', isRequired: true, isSwitch: true, position: 0 }
+            { name: 'providers', isRequired: true, isSwitch: true, isWildcard: false, position: 0 }
         ],
         asyncHandler: execListCommandAsync,
-        helpText: `Usage: *${triggerWord} ${listCommand}* \`providers\`\nList all of the available vaccine providers this bot currently supports.`
+        helpText: `Usage: *${longTriggerWord} ${listCommand}* \`providers\`\nList all of the available vaccine providers this bot currently supports.`
     },
     {
-        name: fromCommand,
+        name: schedulesCommand,
         params: [
-            { name: 'provider', isRequired: true, isSwitch: false, position: 0 },
-            { name: 'state', isRequired: true, isSwitch: false, position: 1 },
-            { name: 'city', isRequired: false, isSwitch: false, position: 2 },
+            { name: 'provider', isRequired: true, isSwitch: false, isWildcard: false, position: 0 },
+            { name: 'state', isRequired: true, isSwitch: false, isWildcard: false, position: 1 },
+            { name: 'city', isRequired: false, isSwitch: false, isWildcard: true, position: 2 },
         ],
         asyncHandler: execFromCommandAsync,
-        helpText: `Usage: *${triggerWord} ${fromCommand}* \`provider_name\`\nLists availability from a specific provider in a state and city. Type \`${triggerWord} ${listCommand} providers\` for a list of valid providers.`
+        helpText: `Usage: *${longTriggerWord} ${schedulesCommand}* \`provider_name\`\nLists availability from a specific provider in a state and city. Type \`${longTriggerWord} ${listCommand} providers\` for a list of valid providers.`
     }
 ];
 
-function isTriggerWord(content) {
-    return content.toLowerCase().startsWith(triggerWord);
+function isLongTriggerWord(content) {
+    return content.toLowerCase().startsWith(longTriggerWord);
+}
+
+function isShortTriggerWord(content) {
+    return content.toLowerCase().startsWith(shortTriggerWord);
 }
 
 function getCmdletDefinition(cmdletName) {
@@ -52,90 +58,23 @@ function getCmdletDefinition(cmdletName) {
     });
 }
 
-function parseCommandTokens(content) {
-    // Preconditon: Is valid command (isCommand() is true)
-
-    let tokens = content.split(' ');
-
-    // First token is triggerCommand, we don't need to validate that again so skip it.
-    if (tokens.length > 1) {
-        let cmdlet = getCmdletDefinition(tokens[1]);
-        if (cmdlet) {
-            // Verify the minimum number of requiredParams have been specified
-            let paramTokens = tokens.slice(2);
-            let requiredParamNames = _.pluck(_.filter(cmdlet.params, function(c) { return c.isRequired === true; }), 'name');
-            let allParamNames = _.pluck(cmdlet.params, 'name');
-            let requiredParamsIntersect = _.intersection(paramTokens, requiredParamNames);
-            let doesCommandUseWildcardParam = cmdlet.params.length === 1 && cmdlet.params[0].name === '*';
-
-            // The intersection of the required params and actual params should be equal. We gate on required params being met only
-            // but our processing loop processs and pairs up all parameters
-            if (doesCommandUseWildcardParam || requiredParamsIntersect.length === requiredParamNames.length) {
-                // Lastly, pair up the params as <param> <value> pairs. Switches will have their value default to true
-                var paramsTable = {};
-
-                // Prime the paramsTable with all the switches set to false.
-                _.map(
-                    _.pluck(
-                        _.filter(cmdlet.params, function(p) { return p.isSwitch === true; })
-                        , 'name'),
-                    function(s) {
-                        paramsTable[s] = false;
-                    });
-
-                // Go through each user-specified param and match them up with a param in the command spec.
-                var wildcardValue = null;
-                if (!doesCommandUseWildcardParam) {
-                    for (var i = 0; i < paramTokens.length; ++i) {
-                        let paramName = paramTokens[i].toLowerCase();
-
-                        // Double check that param name matches the param name in the spec (includes optionals)
-                        if (!_.contains(allParamNames, paramName)) {
-                            return { errorMessage: `\`${paramName}\` is not the correct parameter to use the \`${cmdlet.name}\` command. Here's a reminder:\n${cmdlet.helpText}` };
-                        }
-
-                        let paramSpec = _.find(cmdlet.params, function(p) { return p.name === paramName; });
-                        var paramValue = true;
-                        if (!paramSpec.isSwitch) {
-                            paramValue = paramTokens[++i];
-                        }
-
-                        paramsTable[paramName] = paramValue;
-                    }
-                }
-                else if (paramTokens.length > 0) {
-                    // Commands that use wildcarding only support wildcarding as a solo parameter. We use it to aggregate all parameters into one string and place it
-                    // under a 'wildcardParam' field instead of the params table
-                    wildcardValue = paramTokens.join(' ');
-                }
-
-                return {
-                    command: cmdlet.name,
-                    cmdlet: cmdlet,
-                    params: paramsTable,
-                    wildcardParam: wildcardValue
-                };
-            }
-            
-            return { errorMessage: `We think you wanted the \`${cmdlet.name}\` command, but you're missing some parameters.` };
-        }
-
-        return { errorMessage: `We don\'t recognize that command. Type \`${triggerWord} ${helpCommand}\` for a list of commands.` };
-    }
+function normalizeUrlPathParams(path) {
+    // Technically we can just url encode, but i wanted to keep the URLs looking cleaner for ease of use. So we do some light normalization here.
+    return path.replace(' ', '_');
 }
 
 async function execHelpCommandAsync(message, context) {
     if (context.params.providers) {
         // TODO: List providers from API
     }
-    else if (context.wildcardParam != null) {
-        let commandName = context.wildcardParam;
+    else if (context.params.command) {
+        let commandName = context.params.command;
         let cmdlet = getCmdletDefinition(commandName);
         if (cmdlet) {
             message.channel.send(cmdlet.helpText);
         }
         else {
-            message.channel.send(`The command ${commandName} does not exist. Type ${triggerWord} ${helpCommand} (without any other words after it) to get a list of commands.`);
+            message.channel.send(`The command ${commandName} does not exist. Type ${longTriggerWord} ${helpCommand} (without any other words after it) to get a list of commands.`);
         }
     }
     else {
@@ -153,7 +92,7 @@ async function execFromCommandAsync(message, context) {
     let provider = context.params['provider'];
     let state = context.params['state'];
     let city = context.params['city'] || ``;
-    let path = `/available/${provider}/${state}/${city}`;
+    let path = normalizeUrlPathParams(`/available/${provider}/${state}/${city}`);
     
     let requestOptions = {
         host: settings.vaccineApiHost,
@@ -162,46 +101,47 @@ async function execFromCommandAsync(message, context) {
     }
 
     http.get(requestOptions, function(response) {
-        response.on('data', function(contents) {
+        response.on('data', async function(contents) {
             var contentsAsJson = JSON.parse(contents);
 
             // Pretty it up for discord
             let summary = _.map(contentsAsJson._siteData, function(site) {
                 let appointmentString = site._hasAppointmentsAvailable ? `[Appointments available!](${site._bookingUrl})` : `No appointments available (${site._status})`;
-                return `${site._siteName} - ${site._city}, ${site._state} -> ${appointmentString}`;            
+                return `  ${site._siteName} - ${site._city}, ${site._state} -> ${appointmentString}`;            
             })
 
             //let summaryData = summary.join('\n\n');
             let summaryHeader = `\nAppointment statuses for \`${provider.toUpperCase()}\` sites in state: \`${state.toUpperCase()}\`, filtered by city: ${city.toUpperCase()}\n`;
 
             // Need to chunk things out cuz discord body limits = 2000
-            message.channel.send(summaryHeader);
+            await message.channel.send(summaryHeader);
 
-            var bodyLength = 0;
-            var sliceStart = 0;
-            var sliceEnd = 1;
-            for (var i = 0; i < summary.length; ++i) {
-                let lineBodySize = summary[i].length;
-                if (bodyLength + lineBodySize >= 2000) {
-                    let summaryFragment = summary.slice(sliceStart, sliceEnd).join('\n');
-                    message.channel.send(summaryFragment);
+            await message.channel.send(summary, { split: true });
+            // var bodyLength = 0;
+            // var sliceStart = 0;
+            // var sliceEnd = 1;
+            // for (var i = 0; i < summary.length; ++i) {
+            //     let lineBodySize = summary[i].length;
+            //     if (bodyLength + lineBodySize >= 2000) {
+            //         let summaryFragment = summary.slice(sliceStart, sliceEnd).join('\n');
+            //         await message.channel.send(summaryFragment);
 
-                    bodyLength = lineBodySize;
-                    sliceStart = i;
-                    sliceEnd = i + 1;
-                }
-                else {
-                    bodyLength += lineBodySize;
-                    ++sliceEnd;                    
-                }
-            }
+            //         bodyLength = lineBodySize;
+            //         sliceStart = i;
+            //         sliceEnd = i + 1;
+            //     }
+            //     else {
+            //         bodyLength += lineBodySize;
+            //         ++sliceEnd;                    
+            //     }
+            // }
 
-            // Clear out buffer
-            if (bodyLength > 0) {                
-                message.channel.send(summary.slice(sliceStart, sliceEnd).join('\n'));
-            }
+            //// Clear out buffer
+            // if (bodyLength > 0) {                
+            //     await message.channel.send(summary.slice(sliceStart, sliceEnd).join('\n'));
+            // }
 
-            message.channel.send(`\n\nEnd of data.\nData last timestamp: ${contentsAsJson._timestamp}`);
+            await message.channel.send(`\n\nEnd of data.\nData last timestamp: ${contentsAsJson._timestamp}`);
         });
     });
 }
@@ -214,23 +154,26 @@ client.on("message", message => {
     if (message.author.bot) {
         return;
     }
+    
+    var inputCommand = message.content;
+
+    if (isShortTriggerWord(inputCommand)) {
+        // rewrite the command to imply the "schedules" action
+        inputCommand = inputCommand.replace(shortTriggerWord, `${longTriggerWord}${schedulesCommand} `);
+    }
 
     // Parse content in to commands
-    if (!isTriggerWord(message.content)) {
+    if (!isLongTriggerWord(inputCommand)) {
         // NOOP
         return;
     }
 
-    var parseResults = parseCommandTokens(message.content);
+    var parseResults = CommandParser.parseCommandTokens(inputCommand, cmdletDefinitions);
     if (parseResults.errorMessage) {
         message.channel.send(parseResults.errorMessage);
     }
     else {
         parseResults.cmdlet.asyncHandler(message, parseResults);
-    }
-
-    if (message.content === '!ping') {
-        message.channel.send('Pong.');
     }
 });
 

--- a/src/main.js
+++ b/src/main.js
@@ -113,35 +113,9 @@ async function execFromCommandAsync(message, context) {
             //let summaryData = summary.join('\n\n');
             let summaryHeader = `\nAppointment statuses for \`${provider.toUpperCase()}\` sites in state: \`${state.toUpperCase()}\`, filtered by city: ${city.toUpperCase()}\n`;
 
-            // Need to chunk things out cuz discord body limits = 2000
-            await message.channel.send(summaryHeader);
-
+            message.channel.send(summaryHeader);
             await message.channel.send(summary, { split: true });
-            // var bodyLength = 0;
-            // var sliceStart = 0;
-            // var sliceEnd = 1;
-            // for (var i = 0; i < summary.length; ++i) {
-            //     let lineBodySize = summary[i].length;
-            //     if (bodyLength + lineBodySize >= 2000) {
-            //         let summaryFragment = summary.slice(sliceStart, sliceEnd).join('\n');
-            //         await message.channel.send(summaryFragment);
-
-            //         bodyLength = lineBodySize;
-            //         sliceStart = i;
-            //         sliceEnd = i + 1;
-            //     }
-            //     else {
-            //         bodyLength += lineBodySize;
-            //         ++sliceEnd;                    
-            //     }
-            // }
-
-            //// Clear out buffer
-            // if (bodyLength > 0) {                
-            //     await message.channel.send(summary.slice(sliceStart, sliceEnd).join('\n'));
-            // }
-
-            await message.channel.send(`\n\nEnd of data.\nData last timestamp: ${contentsAsJson._timestamp}`);
+            message.channel.send(`\n\nEnd of data.\nData last timestamp: ${contentsAsJson._timestamp}`);
         });
     });
 }

--- a/template.settings.json
+++ b/template.settings.json
@@ -1,6 +1,5 @@
 {
     "vaccineApiHost": "localhost",
     "vaccineApiPort": 3000,
-    "messageChunkSize": 7,
     "token": "TOKEN HERE"
 }


### PR DESCRIPTION
Parser is now short-form parser, we use implicit positional parameters instead of the super verbosey format.
Added wild-card-y support for end-parameters so they can gobble up the remaining command tokens as one value
Added shortcut to invoke `schedules` command using short-form `!vac` trigger. Long forms and other commands are still accessible through `!vaccine` trigger.