### PR TITLE
Big refactor, added poller, added heartbeat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "discord-vaccine-bot",
+  "name": "discord-vaccine-finder-bot",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/src/commandParser.js
+++ b/src/commandParser.js
@@ -1,21 +1,17 @@
 const _ = require('underscore');
+const CommandProcessor = require('./commandProcessor');
 
-// Just here to declutter main, we still need the cmdletDefinitions to be passed in
 class CommandParser {
-    // Sorry for the dampness. We'll sort this out later
-    static getCmdletDefinition(cmdletName, cmdletDefinitions) {
-        let cmdletToLower = cmdletName.toLowerCase();
-        return _.find(cmdletDefinitions, function(cmd) {
-            return cmd.name === cmdletToLower;
-        });
+    constructor(commandProcessor) {
+        this._commandProcessor = commandProcessor;
     }
 
-    static parseCommandTokens(fullContentString, cmdletDefinitions) {
+    parseCommandTokens(fullContentString) {
         let tokens = fullContentString.split(' ');
 
         // First token is triggerCommand, we don't need to validate that again so skip it.
         if (tokens.length > 1) {
-            let cmdlet = this.getCmdletDefinition(tokens[1], cmdletDefinitions);
+            let cmdlet = this._commandProcessor.getCmdletDefinition(tokens[1]);
             if (cmdlet) {            
                 let paramTokens = tokens.slice(2);
                 let requiredParams = _.filter(cmdlet.params, function(c) { return c.isRequired === true; });            
@@ -76,10 +72,10 @@ class CommandParser {
                 };
             }
 
-            return { errorMessage: `We don\'t recognize that command. Type \`${triggerWord} ${helpCommand}\` for a list of commands.` };
+            return { errorMessage: `We don\'t recognize that command. Type \`${CommandProcessor.longTriggerWord}${CommandProcessor.helpCommand}\` for a list of commands.` };
         }
         else {
-            return { errorMessage: `You need to specify a command. Type \`${triggerWord} ${helpCommand}\` for a list of commands.` };
+            return { errorMessage: `You need to specify a command. Type \`${CommandProcessor.longTriggerWord}${CommandProcessor.helpCommand}\` for a list of commands.` };
         }
     }
 }

--- a/src/commandProcessor.js
+++ b/src/commandProcessor.js
@@ -1,0 +1,180 @@
+const http = require('http');
+const _ = require('underscore');
+
+class CommandProcessor {
+    static longTriggerWord = '!vaccine ';
+    static shortTriggerWord = '!vac ';
+    static helpCommand = 'help';
+    static listCommand = 'list';
+    static schedulesCommand = 'schedules';
+    static onlyAvailableSchedules = 'onlyavailableschedules';
+
+    static normalizeUrlPathParams(path) {
+        // Technically we can just url encode, but i wanted to keep the URLs looking cleaner for ease of use. So we do some light normalization here.
+        return path.replace(' ', '_');
+    }
+
+    cmdletDefinitions = [
+        {
+            name: CommandProcessor.helpCommand,
+            params: [
+                { name: 'command', isRequired: false, isSwitch: false, isWildcard: true, position: 0 }
+            ],
+            asyncHandler: this.execHelpCommandAsync,
+            helpText: `Usage: *${CommandProcessor.longTriggerWord}${CommandProcessor.helpCommand}* [command_name]\n
+\`\`\`Available commands:\n
+${CommandProcessor.listCommand}: List vaccine providers\n
+${CommandProcessor.schedulesCommand}: Shows vaccine availability by provider and state\`\`\``
+        },
+        {
+            name: CommandProcessor.listCommand,
+            params: [
+                { name: 'providers', isRequired: true, isSwitch: true, isWildcard: false, position: 0 }
+            ],
+            asyncHandler: this.execListCommandAsync,
+            helpText: `Usage: *${CommandProcessor.longTriggerWord}${CommandProcessor.listCommand}* \`providers\`\n
+List all of the available vaccine providers this bot currently supports.`
+        },
+        {
+            name: CommandProcessor.schedulesCommand,
+            params: [
+                { name: 'provider', isRequired: true, isSwitch: false, isWildcard: false, position: 0 },
+                { name: 'state', isRequired: true, isSwitch: false, isWildcard: false, position: 1 },
+                { name: 'city', isRequired: false, isSwitch: false, isWildcard: true, position: 2 },
+            ],
+            asyncHandler: this.execSchedulesCommandAsync,
+            helpText: `Usage: *${CommandProcessor.longTriggerWord} ${CommandProcessor.schedulesCommand}* \`provider_name\` \`2_digit_state\` [\`city name\`]\n
+Lists availability from a specific provider in a state and city. Type \`${CommandProcessor.longTriggerWord}${CommandProcessor.listCommand} providers\` for a list of valid providers.`
+        },
+        {
+            name: CommandProcessor.onlyAvailableSchedules,
+            params: [
+                { name: 'provider', isRequired: true, isSwitch: false, isWildcard: false, position: 0 },
+                { name: 'state', isRequired: true, isSwitch: false, isWildcard: false, position: 1 },
+                { name: 'city', isRequired: false, isSwitch: false, isWildcard: true, position: 2 },
+            ],
+            asyncHandler: this.execOnlyAvailableSchedulesCommandAsync,
+            helpText: `Internal command, no help available`
+        },
+    ]
+
+    getCmdletDefinition(cmdletName) {
+        let cmdletToLower = cmdletName.toLowerCase();
+        return _.find(this.cmdletDefinitions, function(cmd) {
+            return cmd.name === cmdletToLower;
+        });
+    }
+
+    async execHelpCommandAsync(channel, context, settings, cmdProc) {
+        if (context.params.command) {
+            // Show help for a specific command. Find the cmdlet definition and get its help text
+            let commandName = context.params.command;
+            let cmdlet = cmdProc.getCmdletDefinition(commandName);
+            if (cmdlet) {
+                channel.send(cmdlet.helpText);
+            }
+            else {
+                channel.send(`The command ${commandName} does not exist. Type ${CommandProcessor.longTriggerWord} ${CommandProcessor.helpCommand} (without any other words after it) to get a list of commands.`);
+            }
+        }
+        else {
+            // Show commands
+            channel.send(context.cmdlet.helpText);
+        }
+    }
+    
+    async execListCommandAsync(channel, context, settings, cmdProc) {
+        let showProviders = context.params['providers'];
+        // TODO: List other things here
+    
+        if (showProviders) {
+            let path = '/list/providers';
+            
+            let requestOptions = {
+                host: settings.vaccineApiHost,
+                port: settings.vaccineApiPort,
+                path: path
+            };
+    
+            http.get(requestOptions, function(response) {
+                response.on('data', function(contents) {
+                    var contentAsJsonArray = JSON.parse(contents);        // it's an array
+                    var quotedNames = _.map(contentAsJsonArray, function(n) {
+                        return `\`${n}\``;
+                    }).join('\n');
+    
+                    channel.send(`Here are the current providers we can pull data from:\n${quotedNames}`);
+                })
+            });
+        }
+    }
+    
+    async execSchedulesCommandAsync(channel, context, settings, cmdProc) {
+        // Calls the /schedules/provider/state/city API
+        let provider = context.params['provider'];
+        let state = context.params['state'];
+        let city = context.params['city'] || '';
+        let path = CommandProcessor.normalizeUrlPathParams(`/schedules/${provider}/${state}/${city}`);
+        
+        let requestOptions = {
+            host: settings.vaccineApiHost,
+            port: settings.vaccineApiPort,
+            path: path
+        };
+    
+        http.get(requestOptions, function(response) {
+            response.on('data', async function(contents) {
+                var contentsAsJson = JSON.parse(contents);
+    
+                // Pretty it up for discord
+                let summary = _.map(contentsAsJson._siteData, function(site) {
+                    let preCursor = site._hasAppointmentsAvailable ? '>> ' : '|  ';
+                    let appointmentString = site._hasAppointmentsAvailable ? `**Appointments available!** (${site._bookingUrl})` : `No appointments available (${site._status})`;
+                    return `\n${preCursor}${site._siteName} / ${site._city.toUpperCase()}, ${site._state} / ${appointmentString}`;
+                })
+    
+                let summaryHeader = `\nAppointment statuses for \`${provider.toUpperCase()}\` sites in state: \`${state.toUpperCase()}\`, filtered by city: ${city.toUpperCase()}`;
+    
+                await channel.send(summaryHeader + summary, { split: true });
+                channel.send(`\nData timestamp: ${contentsAsJson._timestamp}`);
+            });
+        });
+    }
+
+    async execOnlyAvailableSchedulesCommandAsync(channel, context, settings, cmdProc) {
+        // Calls the /schedules/provider/state/city API
+        let provider = context.params['provider'];
+        let state = context.params['state'];
+        let city = context.params['city'] || '';
+        let path = CommandProcessor.normalizeUrlPathParams(`/schedules/${provider}/${state}/${city}`);
+        
+        let requestOptions = {
+            host: settings.vaccineApiHost,
+            port: settings.vaccineApiPort,
+            path: path
+        };
+    
+        http.get(requestOptions, function(response) {
+            response.on('data', async function(contents) {
+                var contentsAsJson = JSON.parse(contents);
+    
+                let availableSites = _.filter(contentsAsJson._siteData, function(site) {
+                    return site._hasAppointmentsAvailable === true;
+                });
+                console.log(`Available sites for ${provider}: ${availableSites.length}`);
+
+                if (availableSites.length > 0) {
+                    let summary = _.map(availableSites, function(site) {                    
+                        let appointmentString = `**Appointments available!** (${site._bookingUrl})`;
+                        return `\n${site._siteName} / ${site._city.toUpperCase()}, ${site._state} / ${appointmentString}`;
+                    });
+        
+                    let summaryHeader = `\nAppointment statuses as of ${contentsAsJson._timestamp} for \`${provider.toUpperCase()}\` sites in state: \`${state.toUpperCase()}\`, filtered by city: ${city.toUpperCase()}`;
+                    await channel.send(summaryHeader + summary, { split: true });                    
+                }
+            });
+        });
+    }
+}
+
+module.exports = CommandProcessor;

--- a/template.settings.json
+++ b/template.settings.json
@@ -1,5 +1,23 @@
 {
     "vaccineApiHost": "localhost",
     "vaccineApiPort": 3000,
-    "token": "TOKEN HERE"
+    "token": "TOKEN HERE",
+    "heartbeatInterval": 0,
+    "heartbeatToChannelId": "811415818595860491",
+    "polling": {
+        "enabled": true,
+        "postToChannelId": "811415818595860491",
+        "cvs": {
+            "rate": 900000,
+            "commands": [
+                "!vaccine onlyAvailableSchedules cvs ny"
+            ]
+        },
+        "nys": {
+            "rate": 900000,
+            "commands": [
+                "!vaccine onlyAvailableSchedules nys ny"
+            ]
+        }
+    }
 }


### PR DESCRIPTION
- Refactored command processing out of main; there's still some jankiness that needs to sorted out but it's working now
- Added polling mechanism and per-site polling configurability
- Added onlyAvailableSchedules command that filters out only available appointments. Look into maybe combining this with the regular schedules command instead, maybe with query param.
- Added heartbeat support