### PR TITLE
Fixed comma issue, fixed hash compare

### DIFF
--- a/src/commands/notifyCommand.js
+++ b/src/commands/notifyCommand.js
@@ -35,13 +35,13 @@ if you only want to be notified from a specific vaccine site.
 
         modeHandlers[stateParam] = function (t) {
             if (self._verifySingleString(t)) {
-                return self._readMultiString(t).join(' ');
+                return self._readSingleString(t);
             }
             return { error: 'value cannot be empty' };
         };
         modeHandlers[cityParam] = function (t) {
             if (self._verifySingleStringWithSpaces(t)) {
-                return self._readMultiString(t).join(' ');
+                return self._readSingleString(t);
             }
             return { error: 'value cannot be empty or contain multiple entries' };
         };
@@ -54,7 +54,7 @@ if you only want to be notified from a specific vaccine site.
         };
         modeHandlers[siteParam] = function (t) {
             if (self._verifySingleStringWithSpaces(t)) {
-                return self._readMultiString(t).join(' ');
+                return self._readSingleString(t);
             }
             return { error: 'value cannot be empty' };
         };
@@ -169,7 +169,7 @@ if you only want to be notified from a specific vaccine site.
             return false;
         }
 
-        return !trimmed.includes(', ');
+        return true;
     }
 
     _verifyMultiString(token) {

--- a/src/commands/onlyAvailableSchedulesCommand.js
+++ b/src/commands/onlyAvailableSchedulesCommand.js
@@ -52,10 +52,14 @@ class OnlyAvailableSchedulesCommand {
                         const vaccineHash = helpers.generateVaccineHash(site._state, site._city, site._siteName);
                         const matchingEvents = self._notifications.findEventsByHash(vaccineHash);
 
+                        console.log(`Found ${matchingEvents.length} matching notification events for hash: ${vaccineHash}`);
                         matchingEvents.forEach(function(e) {
                             e.users.forEach(function(userId) {
                                 discordClient.users.fetch(userId, true)
-                                                    .then(u => u.send(`A vaccine may be available at: ${site._city}, ${site._state} -> ${site._siteName}\nBook at: ${site._bookingUrl}`));
+                                                    .then(u => {
+                                                        console.log(`Sending DM to user: ${u.id} for hash ${vaccineHash}`);
+                                                        u.send(`A vaccine may be available at: ${site._city}, ${site._state} -> ${site._siteName}\nBook at: ${site._bookingUrl}`);
+                                                    });
                             });
                         });
                     });
@@ -63,7 +67,7 @@ class OnlyAvailableSchedulesCommand {
 
                 // If we're triggering without post, then don't post anything to the stated channel
                 if (triggerNotifyNoPost === false) {
-                    let summaryHeader = `\nAppointment statuses as of ${contents._timestamp} for \`${provider.toUpperCase()}\` sites in state: \`${state.toUpperCase()}\`, filtered by city: ${city.toUpperCase()}`;
+                    let summaryHeader = `\nAppointment statuses as of ${contents._timestamp} for \`${provider.toUpperCase()}\` sites in state: \`${state.toUpperCase()}\``;
                     await channel.send(summaryHeader + summary, { split: true });
                 }
             }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -11,13 +11,18 @@ const helpers = {
         return `${nState}-${nCity}-${nSite}`;
     },
 
-    areVaccineHashesEqual(queryHash, staticHash) {
-        const nQueryHash = queryHash.toLowerCase();
-        if (nQueryHash.endsWith('*')) {
-            return staticHash.startsWith(nQueryHash.substring(0, nQueryHash.length - 1));
+    areVaccineHashesEqual(hash1, hash2) {
+        const nHash1 = hash1.toLowerCase();
+        const nHash2 = hash2.toLowerCase();
+        if (nHash1.endsWith('*')) {
+            return hash2.startsWith(nHash1.substring(0, nHash1.length - 1));
         }
 
-        return nQueryHash === staticHash;
+        if (nHash2.endsWith('*')) {
+            return hash1.startsWith(nHash2.substring(0, nHash2.length - 1));
+        }
+
+        return nHash1 === hash2;
     }
 }
 


### PR DESCRIPTION
- Fixed issue where `areHashesEqual` was not associative
- Fixed comma parsing issue when adding sites with commas in their name
- Fixed exception when using `onlyavailableschedules` and it tries to post to a channel without a city value. Since we don't support cities anymore in that command we removed the city var.